### PR TITLE
セッションとタグのリレーション追加実装。タグの登録周りの実装。

### DIFF
--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Session;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class SessionController extends Controller
 {
@@ -17,7 +18,7 @@ class SessionController extends Controller
         $PER_PAGE = 30;
         $page = $request->input('page', 1);
 
-        $sessions = Session::orderBy('created_at', 'desc')->paginate($PER_PAGE, ['*'], 'page', $page);
+        $sessions = Session::with('tags:id,name')->orderBy('created_at', 'desc')->paginate($PER_PAGE, ['*'], 'page', $page);
 
         return response()->json([
             'items' => $sessions->items(),
@@ -26,6 +27,7 @@ class SessionController extends Controller
             'current_page' => $sessions->currentPage(),
             'last_page' => $sessions->lastPage(),
         ]);
+
     }
 
     /**
@@ -36,7 +38,7 @@ class SessionController extends Controller
      */
     public function show($id)
     {
-        $session = Session::find($id);
+        $session = Session::with('tags:id,name')->find($id);
 
         return response()->json($session);
     }

--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -27,7 +27,6 @@ class SessionController extends Controller
             'current_page' => $sessions->currentPage(),
             'last_page' => $sessions->lastPage(),
         ]);
-
     }
 
     /**

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tag;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index(Request $request)
+    {
+        $count = $request->input('count', 'all');
+
+        // countが指定されていない場合は全権件取得
+        if ($count === 'all') {
+            $tags = Tag::select('id', 'name')->orderBy('updated_at', 'desc')->get();
+            return response()->json($tags);
+        }
+        $tags = Tag::select('id', 'name')->orderBy('updated_at', 'desc')->limit($count)->get();
+        return response()->json($tags);
+    }
+}

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -20,4 +20,9 @@ class Session extends Model
         'passion_level',
         'content',
     ];
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class, 'session_tags', 'session_id', 'tag_id');
+    }
 }

--- a/app/Models/SessionTag.php
+++ b/app/Models/SessionTag.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SessionTag extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $table = 'tags';
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            'name' => fake()->realText(10),
+        ];
+    }
+}

--- a/database/migrations/2024_07_13_134926_create_tags_table.php
+++ b/database/migrations/2024_07_13_134926_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->comment('タグ名');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2024_07_13_142723_create_session_tags_table.php
+++ b/database/migrations/2024_07_13_142723_create_session_tags_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Session;
+use App\Models\Tag;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('session_tags', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Session::class)->constrained();
+            $table->foreignIdFor(Tag::class)->constrained();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('session_tags');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Database\Seeders\SessionSeeder;
+use Database\Seeders\TagSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,6 +18,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             SessionSeeder::class,
+            TagSeeder::class,
         ]);
     }
 }

--- a/database/seeders/TagSeeder.php
+++ b/database/seeders/TagSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tag;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Tag::factory(10)->create();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\SessionController;
+use App\Http\Controllers\TagController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -19,76 +20,8 @@ Route::get('/health', function () {
     return 'HelloWorld!Api!';
 });
 
-// TODO：ダミーデータなので実データを返す様に修正する
-// （TOP）タグ一覧
-Route::get('/tags', function () {
-    return response()->json([
-        [
-            'id' => 1,
-            'tag_name' => 'もくもく会'
-        ],
-        [
-            'id' => 2,
-            'tag_name' => '勉強会'
-        ],
-        [
-            'id' => 3,
-            'tag_name' => 'React'
-        ],
-        [
-            'id' => 4,
-            'tag_name' => 'Next.js'
-        ],
-        [
-            'id' => 5,
-            'tag_name' => 'Vue'
-        ],
-        [
-            'id' => 6,
-            'tag_name' => 'Nuxt.js'
-        ],
-        [
-            'id' => 7,
-            'tag_name' => 'Javascript'
-        ],
-        [
-            'id' => 8,
-            'tag_name' => 'Typescript'
-        ],
-        [
-            'id' => 9,
-            'tag_name' => 'Python'
-        ],
-        [
-            'id' => 10,
-            'tag_name' => 'Java'
-        ],
-        [
-            'id' => 11,
-            'tag_name' => 'Go'
-        ],
-        [
-            'id' => 12,
-            'tag_name' => 'Laravel'
-        ],
-        [
-            'id' => 13,
-            'tag_name' => '自然言語処理'
-        ],
-        [
-            'id' => 14,
-            'tag_name' => '機械学習'
-        ],
-        [
-            'id' => 15,
-            'tag_name' => '英会話'
-        ],
-        [
-            'id' => 16,
-            'tag_name' => '数学'
-        ],
-    ]);
-});
+// タグ一覧
+Route::get('/tags', [TagController::class, 'index'])->name('tags');
 
 // （TOP）セッション一覧
 Route::get('/sessions', [SessionController::class, 'index'])->name('index');
@@ -96,6 +29,7 @@ Route::get('/sessions', [SessionController::class, 'index'])->name('index');
 // (セッション)セッション詳細
 Route::get('sessions/{id}', [SessionController::class, 'show'])->name('show');
 
+// (セッション)セッション登録
 Route::post('sessions/register', [SessionController::class, 'register'])->name('register');
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {


### PR DESCRIPTION
Migration,Seeder,Model追加
- Tag
- Session_Tag

API修正
- Session一覧→セッションの中にtag用のパラメータ追加
- Session詳細→レスポンスパラメータにTagsを追加
- タグ一覧→ベタ書きだったものを実データで返すようにした
- Session登録→タグのリレーション、存在しないタグが選択された場合タグを新規追加